### PR TITLE
Cast boolean isSpecialization to int

### DIFF
--- a/v2/sources/META-INF/MANIFEST.MF
+++ b/v2/sources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Database export / import plugin for Archimate Tool
 Bundle-SymbolicName: org.archicontribs.database;singleton:=true
-Bundle-Version: 4.9.4
+Bundle-Version: 4.9.5
 Bundle-Vendor: Herve Jouin
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/v2/sources/src/org/archicontribs/database/connection/DBDatabaseExportConnection.java
+++ b/v2/sources/src/org/archicontribs/database/connection/DBDatabaseExportConnection.java
@@ -2122,7 +2122,7 @@ public class DBDatabaseExportConnection extends DBDatabaseConnection {
 				,profile.getId()
 				,dbMetadata.getCurrentVersion().getVersion()
 				,profile.getName()
-				,profile.isSpecialization()
+				,dbMetadata.isSpecializationAsInteger()
 				,profile.getImagePath()
 				,profile.getConceptType()
 				,System.getProperty("user.name")

--- a/v2/sources/src/org/archicontribs/database/model/DBMetadata.java
+++ b/v2/sources/src/org/archicontribs/database/model/DBMetadata.java
@@ -1057,6 +1057,28 @@ public class DBMetadata  {
     	return null;
     }
     
+    public Boolean isSpecialization() {
+    	if ( this.component instanceof IProfile )
+    		return ((IProfile)this.component).isSpecialization();
+    	return null;
+    }
+    public Integer isSpecializationAsInteger() {
+    	if ( this.component instanceof IProfile )
+    		return ((IProfile)this.component).isSpecialization() ? 1 : 0;
+    	return null;
+    }
+    
+    public void setSpecialization(boolean specialization) {
+    	if ( this.component instanceof IProfile )
+    		((IProfile)this.component).setSpecialization(specialization);
+    }
+    
+    public void setSpecialization(Object specialization) {
+    	if ( this.component instanceof IProfile )
+    		((IProfile)this.component).setSpecialization(DBPlugin.getBooleanValue(specialization));
+    }
+    
+    
     public IProfile getPrimaryProfile() {
     	try {
     		if ( this.component instanceof IProfiles )


### PR DESCRIPTION
Create method isSpecializationAsInteger and use that instead of isSpecialization.
Postgresql supports native boolean type and the jdbc driver does not automatically cast boolean to int, however the plugin creates the is_specialization table as type smallint.

Fixes #149

Signed-off-by: Re4son <re4son@users.noreply.github.com>